### PR TITLE
Tweaks around website URL

### DIFF
--- a/signrelease.sh
+++ b/signrelease.sh
@@ -73,6 +73,7 @@ done
 # VERIFY/COMPARE FILES
 #
 
+gpgconf --reload gpg-agent
 for ext in $ARCHIVE_TYPES; do
     # download file from GitHub
     wget -q "${originGitHub}/archive/${tag}.${ext}" -O "$TMP_DIR/GitHubDownloadedArchive.${ext}"
@@ -84,7 +85,7 @@ for ext in $ARCHIVE_TYPES; do
     fi
 
     # sign archive
-    gpg --armor --detach-sign "$TMP_DIR/${project}-${tag}.${ext}"
+    gpg -u "${originGitHub##*/} release" --armor --detach-sign "$TMP_DIR/${project}-${tag}.${ext}"
 done
 
 

--- a/signrelease.sh
+++ b/signrelease.sh
@@ -100,7 +100,7 @@ for ext in $ARCHIVE_TYPES; do
     rm "$TMP_DIR/${project}-${tag}.${ext}"
 done
 
-echo "Ńow you can upload the *.asc files"
+echo "Now you can upload the *.asc files"
 echo "  from $TMP_DIR"
 echo "  to ${originGitHub}/releases/edit/${tag}"
 echo "."

--- a/signrelease.sh
+++ b/signrelease.sh
@@ -38,6 +38,8 @@ fi
 originGitHubDefault="$( git config --get remote.origin.url )"
 read -rp "Paste GitHub URL here [${originGitHubDefault}]: " originGitHub
 originGitHub=${originGitHub:-$originGitHubDefault}
+originGitHub=${originGitHub/git@github.com:/https://github.com/}
+originGitHub=${originGitHub%.git}
 
 # pre-processing
 TMP_DIR="$(mktemp --tmpdir -d "signrelease/${project}-${tag}-XXXXXXXXXX")"

--- a/signrelease.sh
+++ b/signrelease.sh
@@ -73,6 +73,8 @@ done
 # VERIFY/COMPARE FILES
 #
 
+read -rp "Enter the GPG private key name [${project} release]: " gpgPrivateKey
+gpgPrivateKey=${gpgPrivateKey:-$project release}
 gpgconf --reload gpg-agent
 for ext in $ARCHIVE_TYPES; do
     # download file from GitHub
@@ -85,7 +87,7 @@ for ext in $ARCHIVE_TYPES; do
     fi
 
     # sign archive
-    gpg -u "${originGitHub##*/} release" --armor --detach-sign "$TMP_DIR/${project}-${tag}.${ext}"
+    gpg -u "${gpgPrivateKey}" --armor --detach-sign "$TMP_DIR/${project}-${tag}.${ext}"
 done
 
 


### PR DESCRIPTION
Changes:
- Ensure GitHub URL works when given an ssh URL or one ending in .git
- Ensure gpg agent is loaded, so password only needs to be typed in once
- Support for keyrings with multiple private keys (mine has several repo signing keys, several commit keys, several email keys, debian package signing key, rpm package signing key, ...) - this ensures the right one gets used, but requires the keys to be named in a certain way, so the script can remain generic
- Fix a minor typo