### PR TITLE
fix git archive results in different .tar.gz than on GitHub

### DIFF
--- a/signrelease.sh
+++ b/signrelease.sh
@@ -61,11 +61,20 @@ fi
 
 # create archive
 for ext in $ARCHIVE_TYPES; do
-    echo git archive --prefix="${project}-${tag}/" -o "$TMP_DIR/${project}-${tag}.${ext}" "${tag}"
+    if [ "${ext}" = tar.gz ]; then
+        echo git archive --prefix="${project}-${tag}/" --format tar "${tag}" \| gzip \> "$TMP_DIR/${project}-${tag}.${ext}"
 
-    if ! TZ=$GITHUB_TIME_ZONE git archive --prefix="${project}-${tag}/" -o "$TMP_DIR/${project}-${tag}.${ext}" "${tag}"; then
-        echo "FATAL ERROR: The git archive could not be created."
-        exit 2
+        if ! TZ=$GITHUB_TIME_ZONE git archive --prefix="${project}-${tag}/" --format tar "${tag}" | gzip > "$TMP_DIR/${project}-${tag}.${ext}"; then
+            echo "FATAL ERROR: The git archive could not be created."
+            exit 2
+        fi
+    else
+        echo git archive --prefix="${project}-${tag}/" -o "$TMP_DIR/${project}-${tag}.${ext}" "${tag}"
+
+        if ! TZ=$GITHUB_TIME_ZONE git archive --prefix="${project}-${tag}/" -o "$TMP_DIR/${project}-${tag}.${ext}" "${tag}"; then
+            echo "FATAL ERROR: The git archive could not be created."
+            exit 2
+        fi
     fi
 done
 
@@ -110,4 +119,3 @@ echo "."
 
 # open dir in file manager
 setsid $OPEN_COMMAND "$TMP_DIR"
-


### PR DESCRIPTION
fixes #2, caused by https://github.com/git/git/commit/4f4be00d30

Output from running the latest PrivateBin release 1.7.5 with this fix:

```
$ make sign VERSION=1.7.5
git tag --sign --message "Release v1.7.5" 1.7.5
git push origin 1.7.5
Host key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU
+--[ED25519 256]--+
|                 |
|     .           |
|      o          |
|     o o o  .    |
|     .B S oo     |
|     =+^ =...    |
|    oo#o@.o.     |
|    E+.&.=o      |
|    ooo.X=.      |
+----[SHA256]-----+
[...]
remote: Resolving deltas: 100% (12/12), completed with 12 local objects.
To github.com:PrivateBin/PrivateBin.git
 * [new tag]           1.7.5 -> 1.7.5
signrelease.sh
Executed in /home/[...].
NOTE: You already need to have a published release on GitHub.
Enter the project name [PrivateBin]: 
Enter the tag to sign: 1.7.5
Paste GitHub URL here [git@github.com:PrivateBin/PrivateBin.git]: 
gpg: Signatur vom Sa 16 Nov 2024 08:21:59 CET
gpg:                mittels RSA-Schlüssel 1C2A890AF1135CEC3681666A0F5C940A6BD81F92
gpg: Korrekte Signatur von "El RIDO (key for signing the git commits of the PrivateBin project) <[...]>" [ultimativ]
git archive --prefix=PrivateBin-1.7.5/ --format tar 1.7.5 | gzip > /tmp/signrelease_PrivateBin-1.7.5-o8TBs7pCOm/PrivateBin-1.7.5.tar.gz
git archive --prefix=PrivateBin-1.7.5/ -o /tmp/signrelease_PrivateBin-1.7.5-o8TBs7pCOm/PrivateBin-1.7.5.zip 1.7.5
Enter the GPG private key name [PrivateBin release]: 
Dateien /tmp/signrelease_PrivateBin-1.7.5-o8TBs7pCOm/PrivateBin-1.7.5.tar.gz und /tmp/signrelease_PrivateBin-1.7.5-o8TBs7pCOm/GitHubDownloadedArchive.tar.gz sind identisch.
Dateien /tmp/signrelease_PrivateBin-1.7.5-o8TBs7pCOm/PrivateBin-1.7.5.zip und /tmp/signrelease_PrivateBin-1.7.5-o8TBs7pCOm/GitHubDownloadedArchive.zip sind identisch.
Now you can upload the *.asc files
  from /tmp/signrelease_PrivateBin-1.7.5-o8TBs7pCOm
  to https://github.com/PrivateBin/PrivateBin/releases/edit/1.7.5
.
```
